### PR TITLE
[nrf fromtree] net: openthread: Fix missed logging macro usage

### DIFF
--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -32,12 +32,12 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
 	 */
 
 
-#ifdef OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS
+#ifdef OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME__COUNT_ARGS
 	/* The arguments number has been counted by macro at compile time,
 	 * and the value has been passed in unused (now) aLogRegion.
 	 * If LogRegion value from OT is needed, rewrite macro
-	 * OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS and use higher bits.
-	 * to pass args_num.
+	 * OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME__COUNT_ARGS and use higher
+	 * bits to pass args_num.
 	 */
 	uint32_t args_num = (uint32_t) aLogRegion;
 #else


### PR DESCRIPTION
During recent upmerge OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS
macro was renamed to OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME__COUNT_ARGS
but the code wasn't updated where the macro is actually used.

Upstream PR 30830.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>