### PR TITLE
[nrf temphack] Revert "modules: tfm: cleanup redundant Kconfig...

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -20,7 +20,10 @@ config BOARD
 # force building with TF-M as the Secure Execution Environment.
 
 config BUILD_WITH_TFM
-	default y if BOARD_NRF5340DK_NRF5340_CPUAPPNS || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+	# Temporarily disable building Non-Secure images with TF-M support by
+	# default.
+	# default y if BOARD_NRF5340DK_NRF5340_CPUAPPNS || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+	default n
 
 if BUILD_WITH_TFM
 

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -20,6 +20,12 @@ config TFM_BOARD
 
 menuconfig BUILD_WITH_TFM
 	bool "Build with TF-M as the Secure Execution Environment"
+	select CMSIS_RTOS_V2
+	imply POLL
+	imply THREAD_NAME
+	imply THREAD_STACK_INFO
+	imply INIT_STACKS
+	imply THREAD_MONITOR
 	depends on TRUSTED_EXECUTION_NONSECURE
 	depends on TFM_BOARD != ""
 	depends on ARM_TRUSTZONE_M
@@ -40,6 +46,10 @@ menuconfig BUILD_WITH_TFM
 	    CONFIG_TRUSTED_EXECUTION_NONSECURE ie enabled.
 
 if BUILD_WITH_TFM
+
+config NUM_PREEMPT_PRIORITIES
+	int
+	default 56
 
 config TFM_KEY_FILE_S
 	string "Path to private key used to sign secure firmware images."

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -197,12 +197,19 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
         uicr = uicr_ranges[self.family]
 
-        if not self.force and has_region(uicr, self.hex_):
-            # Hex file has UICR contents.
+        if not self.uicr_data_ok and has_region(uicr, self.hex_):
+            # Hex file has UICR contents, and that's not OK.
             raise RuntimeError(
                 'The hex file contains data placed in the UICR, which '
                 'needs a full erase before reprogramming. Run west '
-                'flash again with --force or --erase.')
+                'flash again with --force, --erase, or --recover.')
+
+    @property
+    def uicr_data_ok(self):
+        # True if it's OK to try to flash even with UICR data
+        # in the image; False otherwise.
+
+        return self.force or self.erase or self.recover
 
     def recover_target(self):
         if self.family == 'NRF53':


### PR DESCRIPTION
... symbol selection"

This reverts commit 0924cb55df52bcf40dc3e0791fa59a13982aa164.

Ref: NCSDK-7591

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>