### PR TITLE
bugfix: twister: Store run_id in csv meta file so it can be reused

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3410,6 +3410,8 @@ class TestSuite(DisablePyTestCollectionMixin):
                     if filter_platform and platform.name not in filter_platform:
                         continue
                     instance = TestInstance(self.testcases[test], platform, self.outdir)
+                    if "run_id" in row and row["run_id"] != "na":
+                        instance.run_id = row["run_id"]
                     if self.device_testing:
                         tfilter = 'runnable'
                     else:
@@ -3991,7 +3993,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         with open(filename, "wt") as csvfile:
             fieldnames = ["test", "arch", "platform", "status",
                           "extra_args", "handler", "handler_time", "ram_size",
-                          "rom_size"]
+                          "rom_size", "run_id"]
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             cw.writeheader()
             for instance in self.instances.values():
@@ -4009,6 +4011,12 @@ class TestSuite(DisablePyTestCollectionMixin):
                     rom_size = instance.metrics.get("rom_size", 0)
                     rowdict["ram_size"] = ram_size
                     rowdict["rom_size"] = rom_size
+                    try:
+                        rowdict["run_id"] = instance.run_id
+                    except AttributeError:
+                        # No run_id available
+                        rowdict["run_id"] = "na"
+
                 cw.writerow(rowdict)
 
     def json_report(self, filename, append=False, version="NA"):


### PR DESCRIPTION
A unique run_id is now also added to the twister.csv file. This
file is used to store meta-data, in particular for `--test-only`
option. The run_id is then reused in `--test-only` calls to verify
if the id from readout matches the expected one.

fixes: #45278

(cherry-picked from edcc85d3d5e701b199cce78cc94c09ad1b325991)
Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>