### PR TITLE
[nrf fromlist] drivers: pinctrl_nrf: Add missing break statements

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -274,6 +274,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			NRF_PSEL_QDEC(reg, B) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
 					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
 		case NRF_FUN_QDEC_LED:
 			NRF_PSEL_QDEC(reg, LED) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
@@ -295,14 +296,17 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			NRF_PSEL_QSPI(reg, IO0) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
 					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
 		case NRF_FUN_QSPI_IO1:
 			NRF_PSEL_QSPI(reg, IO1) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
 					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
 		case NRF_FUN_QSPI_IO2:
 			NRF_PSEL_QSPI(reg, IO2) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
 					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
 		case NRF_FUN_QSPI_IO3:
 			NRF_PSEL_QSPI(reg, IO3) = NRF_GET_PIN(pins[i]);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,


### PR DESCRIPTION
This is a follow-up to commit fd7633126e274a6ed3d411b25d9a10f5224897aa.

For some reason the above commit added several switch cases without
required break statements. In effect, the same pin could get assigned
to multiple signal lines in QDEC or QSPI peripherals if not all pins
were defined for them in devicetree, and consequently these peripherals
could not work properly.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/45439.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>