### PR TITLE
[nrf noup] net: wifi: Add support for WPA supplicant

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -12,6 +12,9 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
+#ifdef CONFIG_WPA_SUPP
+#include "supp_api.h"
+#endif
 
 static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 			void *data, size_t len)
@@ -19,12 +22,15 @@ static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 	struct wifi_connect_req_params *params =
 		(struct wifi_connect_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
+#ifndef CONFIG_WPA_SUPP
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
+
 
 	if (off_api == NULL || off_api->connect == NULL) {
 		return -ENOTSUP;
 	}
+#endif /* CONFIG_WPA_SUPP */
 
 	LOG_HEXDUMP_DBG(params->ssid, params->ssid_length, "ssid");
 	LOG_HEXDUMP_DBG(params->psk, params->psk_length, "psk");
@@ -48,8 +54,11 @@ static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 	    !params->ssid) {
 		return -EINVAL;
 	}
-
+#ifdef CONFIG_WPA_SUPP
+	return z_wpa_supplicant_connect(dev, params);
+#else
 	return off_api->connect(dev, params);
+#endif /* CONFIG_WPA_SUPP */
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT, wifi_connect);
@@ -97,6 +106,10 @@ static int wifi_disconnect(uint32_t mgmt_request, struct net_if *iface,
 			   void *data, size_t len)
 {
 	const struct device *dev = net_if_get_device(iface);
+
+#ifdef CONFIG_WPA_SUPP
+	return z_wpa_supplicant_disconnect(dev);
+#else
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
 
@@ -105,6 +118,7 @@ static int wifi_disconnect(uint32_t mgmt_request, struct net_if *iface,
 	}
 
 	return off_api->disconnect(dev);
+#endif /* CONFIG_WPA_SUPP */
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT, wifi_disconnect);
@@ -169,19 +183,24 @@ static int wifi_iface_status(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct net_wifi_mgmt_offload *off_api =
-		(struct net_wifi_mgmt_offload *) dev->api;
 	struct wifi_iface_status *status = data;
-
-	if (off_api == NULL || off_api->iface_status == NULL) {
-		return -ENOTSUP;
-	}
 
 	if (!data || len != sizeof(*status)) {
 		return -EINVAL;
 	}
 
+#ifdef CONFIG_WPA_SUPP
+	return z_wpa_supplicant_status(dev, status);
+#else
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+
+	if (off_api == NULL || off_api->iface_status == NULL) {
+		return -ENOTSUP;
+	}
+
 	return off_api->iface_status(dev, status);
+#endif /* CONFIG_WPA_SUPP */
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS, wifi_iface_status);
 


### PR DESCRIPTION
If WPA supplicant is enabled at build time, then use the WPA supplicant APIs, else use offload driver APIs. Use z_wpa_supplicant as the name space.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>
Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>
(cherry picked from commit 2104c26cca372536f7a461447ca2afe27f051e7c) (cherry picked from commit be420be0352d575ca4de6e5466043854b828e3e4) (cherry picked from commit 1767131c6d062019d2f30580aeff28f45bf99458)