### PR TITLE
Update nrfx to fix USBD DMA issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 9ae7c765985ebdea3d9b98c0d3b154794f0b47cf
+      revision: 03807f75485c97bd7b9094e0c20e40f8044da9f5
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 03807f75485c97bd7b9094e0c20e40f8044da9f5
+      revision: 092eb78ed1b1551d8f480019b9c05d7371784578
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Cherry-pick both nrfx_pwm and USBD updates in order to make life easier later on. The nrfx_pwm cherry-pick should not cause any issues.