### PR TITLE
[nrf fromlist] sysbuild: introduce Kconfig setting for controlling HC…

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/Kconfig.sysbuild
+++ b/samples/bluetooth/broadcast_audio_sink/Kconfig.sysbuild
@@ -8,3 +8,8 @@ config NET_CORE_BOARD
 	default "nrf5340dk_nrf5340_cpunet" if $(BOARD) = "nrf5340dk_nrf5340_cpuapp"
 	default "nrf5340_audio_dk_nrf5340_cpunet" if $(BOARD) = "nrf5340_audio_dk_nrf5340_cpuapp"
 	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
+
+config NET_CORE_IMAGE_HCI_IPC
+	bool "HCI IPC image on network core"
+	default y
+	depends on NET_CORE_BOARD != ""

--- a/samples/bluetooth/broadcast_audio_sink/sysbuild.cmake
+++ b/samples/bluetooth/broadcast_audio_sink/sysbuild.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT("${SB_CONFIG_NET_CORE_BOARD}" STREQUAL ""))
+if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
 	# For builds in the nrf5340, we build the netcore image with the controller
 
 	set(NET_APP hci_ipc)


### PR DESCRIPTION
…I IPC inclusion

Upstream PR: #65672

Follow-up: #64704

Introducing NET_CORE_IMAGE_HCI_IPC Kconfig setting to control inclusion of HCI IPC image when building through sysbuild.

This allows users with custom netcore applications to avoid inclusion of the default HCI IPC image.